### PR TITLE
Add github actions workflows

### DIFF
--- a/.github/pull-request.yml
+++ b/.github/pull-request.yml
@@ -1,0 +1,145 @@
+name: Pull request
+
+on: pull_request
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install and build
+        uses: ./.github/workflows/actions/build
+
+  linting:
+    name: Code style checks
+    runs-on: ubuntu-latest
+    needs: [build]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore dependencies (from cache)
+        uses: actions/cache/restore@v4
+        with:
+          key: npm-install-${{ hashFiles('package-lock.json') }}
+          path: node_modules
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .tool-versions
+
+      - name: Run linting
+        run: npm run lint
+
+  # tests:
+  #   name: Javascript unit tests
+  #   runs-on: ubuntu-latest
+  #   needs: [build]
+
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+
+  #     - name: Restore dependencies (from cache)
+  #       uses: actions/cache/restore@v4
+  #       with:
+  #         key: npm-install-${{ hashFiles('package-lock.json') }}
+  #         path: node_modules
+
+  #     - name: Restore build (from cache)
+  #       uses: actions/cache/restore@v4
+  #       with:
+  #         path: dist/
+  #         key: build-${{ github.sha }}
+
+  #     - name: Setup Node
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version-file: .tool-versions
+
+  #     - name: Setup Puppeteer
+  #       run: npx puppeteer browsers install
+
+  #     - name: Run tests
+  #       run: npm test --ignore-scripts
+
+  #     - name: Save test coverage
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: Javascript unit tests coverage
+  #         path: coverage
+
+  regression:
+    name: Visual regression tests
+    runs-on: macos-latest
+    needs: [build]
+
+    if: ${{ github.base_ref == 'main' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes
+        id: changes
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: '.tool-versions'
+          cache: poetry
+
+      - name: Setup Playwright
+        run: npm run postinstall
+
+      - name: Run backstop
+        run: npm run test:visual --ignore-scripts
+
+      - name: Save backstop report
+        if: ${{ !cancelled() && steps.changes.outputs.changes == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Backstop report
+          path: tests/backstop/
+          if-no-files-found: ignore
+
+  # sonar:
+  #   name: Sonar analysis
+  #   runs-on: ubuntu-latest
+  #   needs: [build, tests]
+
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+  #   steps:
+  #     - name: Checkout
+  #       if: ${{ env.SONAR_TOKEN }}
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Restore test coverage
+  #       if: ${{ env.SONAR_TOKEN }}
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: Javascript unit tests coverage
+  #         path: coverage
+
+  #     - name: Sonar analysis
+  #       if: ${{ env.SONAR_TOKEN }}
+  #       uses: SonarSource/sonarqube-scan-action@v5

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,62 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Create release
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nhsuk_frontend_jinja
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: '.tool-versions'
+          cache: poetry
+
+      - name: Build
+        run: poetry build
+
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1      
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          "$GITHUB_REF_NAME"
+          --repo "$GITHUB_REPOSITORY"
+          --notes ""
+
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: >-
+          gh release upload
+          "$GITHUB_REF_NAME" dist/**
+          --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## CI workflow
- This does the visual regression tests and linting
- Unit tests to be added once we have a means of fetching fixtures & expected HTML from nhs-frontend ([Jira ticket](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8430), https://github.com/nhsuk/nhsuk-frontend/issues/1099)

## Release workflow
- This is blocked until we set up / gain access to a pypi account. Once we've got that we will set this repo as a trusted publisher (see https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)
- Workflow is triggered by pushing a tag