### PR TITLE
fix: ensure input passed label.id down to label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK frontend jinja changelog
 
+## 0.7.2
+
+### :wrench: **Fixes**
+
+- [#1797: Ensure input passes label.id down to the label](https://github.com/nhsuk/nhsuk-frontend/pull/1797)
+
 ## 0.7.1
 
 ### :wrench: **Fixes**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following table shows the version of NHS.UK frontend jinja that you should u
 | 10.2.0 | 0.6.0 |
 | 10.2.2 | 0.6.1 |
 | 10.3.0 | 0.7.0 |
-| 10.3.1 | 0.7.1 |
+| 10.3.1 | 0.7.2 |
 
 ### Configuration
 

--- a/nhsuk_frontend_jinja/templates/nhsuk/components/checkboxes/template.jinja
+++ b/nhsuk_frontend_jinja/templates/nhsuk/components/checkboxes/template.jinja
@@ -50,6 +50,7 @@
         {{- nhsukAttributes(item.attributes) }}>
       {{ label({
         "html": item.html,
+        "id": item.label.id,
         "text": item.text,
         "classes": "nhsuk-checkboxes__label" ~ (" " ~ item.label.classes if item.label.classes),
         "size": item.label.size,

--- a/nhsuk_frontend_jinja/templates/nhsuk/components/date-input/template.jinja
+++ b/nhsuk_frontend_jinja/templates/nhsuk/components/date-input/template.jinja
@@ -73,6 +73,7 @@
     <div class="nhsuk-date-input__item">
       {{ input({
         "label": {
+          "id": item.label.id,
           "text": item.label if item.label else item.name | capitalize,
           "classes": "nhsuk-date-input__label"
         },

--- a/nhsuk_frontend_jinja/templates/nhsuk/components/file-upload/template.jinja
+++ b/nhsuk_frontend_jinja/templates/nhsuk/components/file-upload/template.jinja
@@ -64,6 +64,7 @@
   {{- nhsukAttributes(params.formGroup.attributes) }}>
   {{ label({
     "html": params.label.html,
+    "id": params.label.id,
     "text": params.label.text,
     "classes": params.label.classes,
     "size": params.label.size,

--- a/nhsuk_frontend_jinja/templates/nhsuk/components/input/template.jinja
+++ b/nhsuk_frontend_jinja/templates/nhsuk/components/input/template.jinja
@@ -97,6 +97,7 @@
   {{ label({
     "html": params.label.html,
     "text": params.label.text,
+    "id": params.label.id,
     "classes": params.label.classes,
     "size": params.label.size,
     "isPageHeading": params.label.isPageHeading,

--- a/nhsuk_frontend_jinja/templates/nhsuk/components/radios/template.jinja
+++ b/nhsuk_frontend_jinja/templates/nhsuk/components/radios/template.jinja
@@ -41,6 +41,7 @@
         {{- nhsukAttributes(item.attributes) }}>
       {{ label({
         "html": item.html,
+        "id": item.label.id,
         "text": item.text,
         "classes": "nhsuk-radios__label" ~ (" " ~ item.label.classes if item.label.classes),
         "size": item.label.size,

--- a/nhsuk_frontend_jinja/templates/nhsuk/components/select/template.jinja
+++ b/nhsuk_frontend_jinja/templates/nhsuk/components/select/template.jinja
@@ -43,6 +43,7 @@
   {{- nhsukAttributes(params.formGroup.attributes) }}>
   {{ label({
     "html": params.label.html,
+    "id": params.label.id,
     "text": params.label.text,
     "classes": params.label.classes,
     "size": params.label.size,

--- a/nhsuk_frontend_jinja/templates/nhsuk/components/textarea/template.jinja
+++ b/nhsuk_frontend_jinja/templates/nhsuk/components/textarea/template.jinja
@@ -13,6 +13,7 @@
   {{- nhsukAttributes(params.formGroup.attributes) }}>
   {{ label({
     "html": params.label.html,
+    "id": params.label.id,
     "text": params.label.text,
     "classes": params.label.classes,
     "size": params.label.size,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nhsuk-frontend-jinja"
-version = "0.7.1"
+version = "0.7.2"
 description = "A port of NHS.UK frontend templates for the Jinja templating engine."
 authors = [{ name = "Mat Moore", email = "MatMoore@users.noreply.github.com" }]
 license = { text = "MIT" }


### PR DESCRIPTION
Previously label.id was being ignored when passed to the input component, and we need this fixed for the stepper component in manage breast screening.

It doesn't matter if this gets merged before or after the [upstream PR](https://github.com/nhsuk/nhsuk-frontend/pull/1797).