### PR TITLE
regenerate uv lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "nhsuk-frontend-jinja"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
I merged a PR created before the uv switch without rebasing, so the lockfile is now out of date with the version in pyproject.toml.